### PR TITLE
Add ffmpeg dependency for EL7 on build-time

### DIFF
--- a/mpv.spec
+++ b/mpv.spec
@@ -28,6 +28,10 @@ BuildRequires:  waf
 BuildRequires:  rst2pdf
 %endif
 
+%if 0%{?rhel} ==7
+BuildRequires:  ffmpeg
+%endif
+
 %ifarch x86_64
 BuildRequires:  nvidia-driver-devel
 BuildRequires:  cuda-devel >= 7.5


### PR DESCRIPTION
To build with upstream ffmpeg instead of /old/ compat-ffmpeg, EL7 needs to have explicit ffmpeg dependency on build-time to solve the deps for libav* against upstream version instead of compat.
in newer distros, dnf resolves the dependency correctly (ffmpeg-devel > compat-ffmpeg-devel), but yum does not.

the following logs show the same srpm on el7 and fedora-25. el7 builds against 2.8.10, fedora-25 against 3.2.2:
el7 copr build log : https://copr-be.cloud.fedoraproject.org/results/lsde/mpv/epel-7-x86_64/00494743-mpv/root.log.gz
fedora-25 copr build log : https://copr-be.cloud.fedoraproject.org/results/lsde/mpv/fedora-25-x86_64/00494742-mpv/root.log.gz

This log shows the correct behavior with patched srpm on el7:
https://copr-be.cloud.fedoraproject.org/results/lsde/mpv/epel-7-x86_64/00494735-mpv/root.log.gz