### PR TITLE
Add libshaderc dependency for Vulkan support with NVidia 410 drivers.

### DIFF
--- a/mpv.spec
+++ b/mpv.spec
@@ -6,7 +6,7 @@
 Name:           mpv
 Version:        0.29.1
 Release:        1%{?dist}
-Epoch:          1
+Epoch:          2
 Summary:        Movie player playing most video formats and DVDs
 License:        GPLv2+ and LGPLv2+
 URL:            http://%{name}.io/
@@ -52,6 +52,7 @@ BuildRequires:  pkgconfig(libcdio)
 BuildRequires:  pkgconfig(libcdio_paranoia)
 BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(libpulse) >= 1.0
+BuildRequires:  pkgconfig(libshaderc)
 BuildRequires:  pkgconfig(libswresample) >= 3.0.100
 BuildRequires:  pkgconfig(libswscale) >= 5.0.101
 BuildRequires:  pkgconfig(libv4l2)
@@ -189,6 +190,10 @@ fi
 %{_libdir}/pkgconfig/mpv.pc
 
 %changelog
+* Mon Oct 22 2018 Simone Caronni <negativo17@gmail.com> - 1:0.29.1-2
+- Add libshaderc dependency for Vulkan support with NVidia 410 drivers
+  (thanks Jens Peters).
+
 * Sat Oct 20 2018 Simone Caronni <negativo17@gmail.com> - 1:0.29.1-1
 - Update to 0.29.1.
 


### PR DESCRIPTION
This PR adds a dependency to libshaderc. This is needed for having Vulkan support for Nvidia 410 drivers, otherwise Vulkan output fails with "Failed initializing SPIR-V compiler" with this new  driver.

According to https://github.com/mpv-player/mpv/issues/6124#issuecomment-421444905 mpv uses either the `VK_NV_glsl_shader` extension or libshaderc. Since `VK_NV_glsl_shader` is now deprecated and no longer part of the 410 driver series we thus need libshaderc.

Note: I don't know if libshaderc is available on CentOS, I assume it is.